### PR TITLE
Course dashboard many-to-many example

### DIFF
--- a/EFCoreRelationshipsSample/Controllers/CourseDashboardController.cs
+++ b/EFCoreRelationshipsSample/Controllers/CourseDashboardController.cs
@@ -1,0 +1,62 @@
+﻿using EFCoreRelationshipsSample.Data;
+using EFCoreRelationshipsSample.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFCoreRelationshipsSample.Controllers;
+
+public class CourseDashboardController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public CourseDashboardController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> CourseRosters()
+    {
+        // Get a list of courses that have enrolled students
+        List<Course> courses = await _context.Courses
+            .Include(course => course.Students)
+            .Where(course => course.Students.Any())
+            .ToListAsync();
+
+        // Students not enrolled in any course
+        List<Student> unenrolledStudents = await _context.Students
+            .Where(student => !student.Courses.Any())
+            .ToListAsync();
+
+        // Courses with no students enrolled
+        List<Course> emptyCourses = await _context.Courses
+            .Where(course => !course.Students.Any())
+            .ToListAsync();
+
+        CourseDashboardViewModel viewModel = new()
+        {
+            Courses = courses,
+            UnenrolledStudents = unenrolledStudents,
+            EmptyCourses = emptyCourses
+        };
+
+        return View(viewModel);
+    }
+}
+
+public class CourseDashboardViewModel
+{
+    /// <summary>
+    /// List of courses and their associated students
+    /// </summary>
+    public ICollection<Course> Courses { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the list of students who are not currently enrolled in any course.
+    /// </summary>
+    public ICollection<Student> UnenrolledStudents { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the collection of courses that currently have no enrolled students.
+    /// </summary>
+    public ICollection<Course> EmptyCourses { get; set; } = [];
+}

--- a/EFCoreRelationshipsSample/Controllers/CourseDashboardController.cs
+++ b/EFCoreRelationshipsSample/Controllers/CourseDashboardController.cs
@@ -46,7 +46,8 @@ public class CourseDashboardController : Controller
 public class CourseDashboardViewModel
 {
     /// <summary>
-    /// List of courses and their associated students
+    /// List of courses and their associated students. This property should
+    /// only contain courses that have at least 1 student. NO EMPTY COURSES
     /// </summary>
     public ICollection<Course> Courses { get; set; } = [];
 

--- a/EFCoreRelationshipsSample/Models/CourseDashboardViewModel.cs
+++ b/EFCoreRelationshipsSample/Models/CourseDashboardViewModel.cs
@@ -1,0 +1,20 @@
+namespace EFCoreRelationshipsSample.Models;
+
+public class CourseDashboardViewModel
+{
+    /// <summary>
+    /// List of courses and their associated students. This property should
+    /// only contain courses that have at least 1 student. NO EMPTY COURSES
+    /// </summary>
+    public ICollection<Course> Courses { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the list of students who are not currently enrolled in any course.
+    /// </summary>
+    public ICollection<Student> UnenrolledStudents { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the collection of courses that currently have no enrolled students.
+    /// </summary>
+    public ICollection<Course> EmptyCourses { get; set; } = [];
+}

--- a/EFCoreRelationshipsSample/Models/ManyToMany.cs
+++ b/EFCoreRelationshipsSample/Models/ManyToMany.cs
@@ -1,7 +1,9 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 
 namespace EFCoreRelationshipsSample.Models;
 
+[DebuggerDisplay($"Course: {{{nameof(CourseTitle)}}}, Credits: {{{nameof(Credits)}}}")]
 public class Course
 {
     [Key]
@@ -14,6 +16,7 @@ public class Course
     public ICollection<Student> Students { get; set; } = [];
 }
 
+[DebuggerDisplay($"Student: {{{nameof(FullName)}}}")]
 public class Student
 {
     [Key]

--- a/EFCoreRelationshipsSample/Program.cs
+++ b/EFCoreRelationshipsSample/Program.cs
@@ -1,4 +1,5 @@
 using EFCoreRelationshipsSample.Data;
+using EFCoreRelationshipsSample.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +13,10 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddEntityFrameworkStores<ApplicationDbContext>();
+
+// Register application services
+builder.Services.AddScoped<ICourseService, CourseService>();
+
 builder.Services.AddControllersWithViews();
 
 var app = builder.Build();

--- a/EFCoreRelationshipsSample/Services/CourseService.cs
+++ b/EFCoreRelationshipsSample/Services/CourseService.cs
@@ -1,6 +1,0 @@
-using EFCoreRelationshipsSample.Data;
-using EFCoreRelationshipsSample.Models;
-using Microsoft.EntityFrameworkCore;
-
-namespace EFCoreRelationshipsSample.Services;
-

--- a/EFCoreRelationshipsSample/Services/CourseService.cs
+++ b/EFCoreRelationshipsSample/Services/CourseService.cs
@@ -1,0 +1,6 @@
+using EFCoreRelationshipsSample.Data;
+using EFCoreRelationshipsSample.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFCoreRelationshipsSample.Services;
+

--- a/EFCoreRelationshipsSample/Services/ICourseService.cs
+++ b/EFCoreRelationshipsSample/Services/ICourseService.cs
@@ -1,5 +1,6 @@
 using EFCoreRelationshipsSample.Data;
 using EFCoreRelationshipsSample.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace EFCoreRelationshipsSample.Services;
 

--- a/EFCoreRelationshipsSample/Services/ICourseService.cs
+++ b/EFCoreRelationshipsSample/Services/ICourseService.cs
@@ -1,0 +1,46 @@
+using EFCoreRelationshipsSample.Data;
+using EFCoreRelationshipsSample.Models;
+
+namespace EFCoreRelationshipsSample.Services;
+
+public interface ICourseService
+{
+    Task<List<Course>> GetCoursesWithStudentsAsync();
+    Task<List<Student>> GetUnenrolledStudentsAsync();
+    Task<List<Course>> GetEmptyCoursesAsync();
+}
+
+public class CourseService : ICourseService
+{
+    private readonly ApplicationDbContext _context;
+
+    public CourseService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<Course>> GetCoursesWithStudentsAsync()
+    {
+        return await _context.Courses
+            .AsNoTracking()
+            .Include(course => course.Students)
+            .Where(course => course.Students.Any())
+            .ToListAsync();
+    }
+
+    public async Task<List<Student>> GetUnenrolledStudentsAsync()
+    {
+        return await _context.Students
+            .AsNoTracking()
+            .Where(student => !student.Courses.Any())
+            .ToListAsync();
+    }
+
+    public async Task<List<Course>> GetEmptyCoursesAsync()
+    {
+        return await _context.Courses
+            .AsNoTracking()
+            .Where(course => !course.Students.Any())
+            .ToListAsync();
+    }
+}

--- a/EFCoreRelationshipsSample/Views/CourseDashboard/CourseRosters.cshtml
+++ b/EFCoreRelationshipsSample/Views/CourseDashboard/CourseRosters.cshtml
@@ -1,0 +1,75 @@
+﻿@model CourseDashboardViewModel
+
+@{
+	ViewData["Title"] = "Course Rosters";
+}
+
+<h2>Course Rosters</h2>
+@if (Model.Courses.Any())
+{
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Course Name</th>
+				<th>Enrolled Students</th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var course in Model.Courses)
+			{
+				<tr>
+					<td>@course.CourseTitle</td>
+					<td>
+						@if (course.Students.Any())
+						{
+							<ul>
+								@foreach (var student in course.Students)
+								{
+									<li>@student.FullName</li>
+								}
+							</ul>
+						}
+						else
+						{
+							<em>No students enrolled</em>
+						}
+					</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+else
+{
+	<p>No courses available.</p>
+}
+
+<h2>Unenrolled Students</h2>
+@if (Model.UnenrolledStudents.Any())
+{
+	<ul>
+		@foreach (var student in Model.UnenrolledStudents)
+		{
+			<li>@student.FullName</li>
+		}
+	</ul>
+}
+else
+{
+	<p>All students are enrolled in at least one course.</p>
+}
+
+<h2>Empty Courses</h2>
+@if (Model.EmptyCourses.Any())
+{
+	<ul>
+		@foreach (var course in Model.EmptyCourses)
+		{
+			<li>@course.CourseTitle</li>
+		}
+	</ul>
+}
+else
+{
+	<p>All courses have enrolled students.</p>
+}

--- a/EFCoreRelationshipsSample/Views/Home/Index.cshtml
+++ b/EFCoreRelationshipsSample/Views/Home/Index.cshtml
@@ -25,4 +25,7 @@
     <li>
 		<a asp-controller="Courses" asp-action="Index">View course details to see student roster</a>
     </li>
+    <li>
+        <a asp-controller="CourseDashboard" asp-action="CourseRosters">See all course rosters</a>
+    </li>
 </ul>

--- a/EFCoreRelationshipsSample/Views/Home/Index.cshtml
+++ b/EFCoreRelationshipsSample/Views/Home/Index.cshtml
@@ -22,4 +22,7 @@
     <li>
         <a asp-controller="Students" asp-action="Index">Edit a student to see their course enrollment</a>
 	</li>
+    <li>
+		<a asp-controller="Courses" asp-action="Index">View course details to see student roster</a>
+    </li>
 </ul>

--- a/EFCoreRelationshipsSample/Views/_ViewImports.cshtml
+++ b/EFCoreRelationshipsSample/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using EFCoreRelationshipsSample
 @using EFCoreRelationshipsSample.Models
+@using EFCoreRelationshipsSample.Controllers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
This pull request introduces a new course dashboard feature that provides a summary view of course rosters, unenrolled students, and empty courses. It adds a dedicated controller, view model, service layer, and a Razor view to support the dashboard, as well as updates to the navigation and model debugging support.

**Course Dashboard Feature:**

* Added `CourseDashboardController` to handle course roster requests and assemble the dashboard view model using the new service layer.
* Introduced `CourseDashboardViewModel` to organize courses with students, unenrolled students, and empty courses for the dashboard view.
* Created `ICourseService` interface and `CourseService` implementation to provide methods for fetching courses with students, unenrolled students, and empty courses. Registered this service for dependency injection. [[1]](diffhunk://#diff-089d98592d4960a1732409fb49f48d3d2d9caf6745b0a3cbbba9220ceb820d9cR1-R46) [[2]](diffhunk://#diff-f302c5f5100d5cb5270577445ba4684af96631db0f61291297d4e73c2e250b7fR16-R19) [[3]](diffhunk://#diff-3e37af3016ef1b81cc9bdc517fa04821a895f874f8f80a1dd70706876819f586R1-R6)
* Added `CourseRosters.cshtml` Razor view to display the dashboard with tables and lists for courses, students, and empty courses.
* Updated navigation in `Index.cshtml` to include a link to the new course dashboard.

**Model and Debugging Improvements:**

* Added `[DebuggerDisplay]` attributes to `Course` and `Student` classes for improved debugging output. [[1]](diffhunk://#diff-5cafca64d4ebe1424df36b5971a2efc029daf423fcd507627a5e32e13e507fd3R2-R6) [[2]](diffhunk://#diff-5cafca64d4ebe1424df36b5971a2efc029daf423fcd507627a5e32e13e507fd3R19)